### PR TITLE
Small patch

### DIFF
--- a/lib/barista/compiler.rb
+++ b/lib/barista/compiler.rb
@@ -55,7 +55,12 @@ module Barista
     def invoke_coffee(path)
       command = "#{self.class.bin_path} #{coffee_options} '#{path}'".squeeze(' ')
       Barista.invoke_hook :before_compilation, path
-      pid, stdin, stdout, stderr = Open4.popen4(command)
+ 
+      #jruby cannot use open4 because it uses fork. 
+      #This should hopefully work for both jruby and ruby
+      popen_class = IO.respond_to?(:popen4) ? IO : Open4
+ 
+      pid, stdin, stdout, stderr = popen_class.popen4(command)
       stdin.close
       _, status = Process.waitpid2(pid)
       out = stdout.read.strip


### PR DESCRIPTION
I thought I'd tell you that barista does not work with jruby because it uses the Open4 gem which uses fork.
([JRuby doesn't implement fork() on any platform, including those where fork() is available in MRI.](http://kenai.com/projects/jruby/pages/DifferencesBetweenMriAndJruby#Fork_is_not_implemented))

But I thought I'd see if I could fix it myself first and it was a lot easier than I thought. This patch seems to suffice.
