### PR TITLE
Add preamble to generated files

### DIFF
--- a/lib/barista.rb
+++ b/lib/barista.rb
@@ -140,6 +140,10 @@ module Barista
       Rails.env.test? || Rails.env.development?
     end
 
+    def add_preamble?
+      Rails.env.test? || Rails.env.development?
+    end
+
     def no_wrap?
       defined?(@no_wrap) && @no_wrap
     end

--- a/lib/barista/compiler.rb
+++ b/lib/barista/compiler.rb
@@ -31,7 +31,7 @@ module Barista
 
     def compile!
       # Compiler code thanks to bistro_car.
-      @compiled_content = "/* DO NOT MODIFY. This file was compiled from #{@path}. */\n\n" + 
+      @compiled_content = "/* DO NOT MODIFY. This file was compiled from\n *   #{@path}\n */\n\n" + 
                           invoke_coffee(@path)
       @compiled = true
     end

--- a/lib/barista/compiler.rb
+++ b/lib/barista/compiler.rb
@@ -31,8 +31,8 @@ module Barista
 
     def compile!
       # Compiler code thanks to bistro_car.
-      @compiled_content = "/* DO NOT MODIFY. This file was compiled from\n *   #{@path}\n */\n\n" + 
-                          invoke_coffee(@path)
+      @compiled_content = invoke_coffee(@path)
+      @compiled_content = preamble + @compiled_content if Barista.add_preamble?
       @compiled = true
     end
 
@@ -46,6 +46,10 @@ module Barista
     end
 
     protected
+
+    def preamble
+      "/* DO NOT MODIFY. This file was compiled from\n *   #{@path}\n */\n\n"
+    end
 
     def coffee_options
       ["-p"].tap do |options|

--- a/lib/barista/compiler.rb
+++ b/lib/barista/compiler.rb
@@ -31,7 +31,7 @@ module Barista
 
     def compile!
       # Compiler code thanks to bistro_car.
-      @compiled_content = "/* DO NOT MODIFY. This file was compiled from #{path}. */\n\n" + 
+      @compiled_content = "/* DO NOT MODIFY. This file was compiled from #{@path}. */\n\n" + 
                           invoke_coffee(@path)
       @compiled = true
     end

--- a/lib/barista/compiler.rb
+++ b/lib/barista/compiler.rb
@@ -31,7 +31,8 @@ module Barista
 
     def compile!
       # Compiler code thanks to bistro_car.
-      @compiled_content = invoke_coffee(@path)
+      @compiled_content = "/* DO NOT MODIFY. This file was compiled from #{path}. */\n\n" + 
+                          invoke_coffee(@path)
       @compiled = true
     end
 


### PR DESCRIPTION
Adds the following comment to the top of compiled files in dev and test environments:

```
/* DO NOT MODIFY. This file was compiled from
 *   /Users/xavier/Code/testapp/app/coffeescripts/article_edit.coffee
 */
```

Cheers mate, loving this plugin.
Xavier
