### PR TITLE
Changed --no-wrap to --bare

### DIFF
--- a/lib/barista/compiler.rb
+++ b/lib/barista/compiler.rb
@@ -53,7 +53,7 @@ module Barista
 
     def coffee_options
       ["-p"].tap do |options|
-        options << "--no-wrap" if Barista.no_wrap?
+        options << "--bare" if Barista.no_wrap?
       end.join(" ")
     end
 


### PR DESCRIPTION
In the latest version of coffee script the option for --no-wrap was changed to --bare 
