### PR TITLE
OK, this time it's against HEAD. :)

### DIFF
--- a/lib/barista/compiler.rb
+++ b/lib/barista/compiler.rb
@@ -107,7 +107,8 @@ module Barista
     rescue CoffeeScript::Error => e
       Barista.invoke_hook :compilation_failed, where, e.message
       if Barista.exception_on_error? && !@options[:silence]
-        raise CompilationError, "CoffeeScript encountered an error compiling #{where}: #{e.message}"
+        where_within_app = where.sub(/#{Regexp.escape(Barista.app_root)}\/?/, '')
+        raise CompilationError, "Error: In #{where_within_app}, #{e.message}"
       end
       compilation_error_for where, e.message
     end

--- a/lib/barista/compiler.rb
+++ b/lib/barista/compiler.rb
@@ -107,8 +107,12 @@ module Barista
     rescue CoffeeScript::Error => e
       Barista.invoke_hook :compilation_failed, where, e.message
       if Barista.exception_on_error? && !@options[:silence]
-        where_within_app = where.sub(/#{Regexp.escape(Barista.app_root)}\/?/, '')
-        raise CompilationError, "Error: In #{where_within_app}, #{e.message}"
+        if e.is_a?(CoffeeScript::CompilationError)
+          where_within_app = where.sub(/#{Regexp.escape(Barista.app_root)}\/?/, '')
+          raise CompilationError, "Error: In #{where_within_app}, #{e.message}"
+        else
+          raise CompilationError, "CoffeeScript encountered an error compiling #{where}: #{e.message}"
+        end
       end
       compilation_error_for where, e.message
     end

--- a/lib/barista/compiler.rb
+++ b/lib/barista/compiler.rb
@@ -90,7 +90,7 @@ module Barista
     def compile!
       location          = @options.fetch(:origin, 'inline')
       @compiled_content = compile(@context, location)
-      @compiled_content = preamble(location) + @compiled_content if Barista.add_preamble?
+      @compiled_content = preamble(location) + @compiled_content if Barista.add_preamble? unless location == 'inline'
       @compiled         = true
     end
 

--- a/lib/barista/compiler.rb
+++ b/lib/barista/compiler.rb
@@ -108,7 +108,7 @@ module Barista
       Barista.invoke_hook :compilation_failed, where, e.message
       if Barista.exception_on_error? && !@options[:silence]
         if e.is_a?(CoffeeScript::CompilationError)
-          where_within_app = where.sub(/#{Regexp.escape(Barista.app_root)}\/?/, '')
+          where_within_app = where.sub(/#{Regexp.escape(Barista.app_root.to_s)}\/?/, '')
           raise CompilationError, "Error: In #{where_within_app}, #{e.message}"
         else
           raise CompilationError, "CoffeeScript encountered an error compiling #{where}: #{e.message}"


### PR DESCRIPTION
On compile error, raise the error that coffee returned. On other (internal) errors, raise a generic error like before.
