### PR TITLE
Provide a way to use generated JS file

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ and `#option!` (to set the value to true):
 * `add_preamble` - Add a time + path preamble to compiled JS. (Defaults to true in test / dev)
 * `exception_on_error` - Raise an exception on compilation errors (defaults to true)
 * `embedded_interpreter` - Embeds coffeescript + link to coffee file instead of compiling for include tags and haml filters. (Defaults to true in test / dev)
+* `auto_compile` - Automatically compile coffeescript to JS when coffeescript is newer than generated JS file. After turn it off, your server will use generated JS file directly and won't depend on any coffeescript compilers. (Defaults is true)
+
 
 ### Path options
 

--- a/lib/barista.rb
+++ b/lib/barista.rb
@@ -52,7 +52,7 @@ module Barista
 
     # Configuration - Tweak how you use Barista.
     
-    has_boolean_options    :verbose, :bare, :add_filter, :add_preamble, :exception_on_error, :embedded_interpreter
+    has_boolean_options    :verbose, :bare, :add_filter, :add_preamble, :exception_on_error, :embedded_interpreter, :auto_compile
     has_delegate_methods   Compiler, :bin_path, :bin_path=, :js_path, :js_path=
     has_deprecated_methods :compiler, :compiler=, :compiler_klass, :compiler_klass=
     
@@ -164,6 +164,11 @@ module Barista
     def default_for_embedded_interpreter
       local_env?
     end
+
+    def default_for_auto_compile
+      true
+    end
+
 
     # Actual tasks on the barista module.
 

--- a/lib/generators/barista/install/templates/initializer.rb
+++ b/lib/generators/barista/install/templates/initializer.rb
@@ -6,6 +6,9 @@ Barista.configure do |c|
   
   # Change the output root, causing Barista to compile into public/coffeescripts
   # c.output_root = Rails.root.join("public", "coffeescripts")
+  #
+  # Disable auto compile, use generated file directly:
+  # c.auto_compile = false
   
   # Set the compiler
   


### PR DESCRIPTION
The problem I met is I can not install therubytracer on heroku successfully.  
I found this folk https://github.com/aler/therubyracer-heroku, it works but It is not a finally solution.
I think the finally solution is add a switch to use generated JS file directly.
