### PR TITLE
In the README.md the dependecy with json was missing 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ easier. You can think of it as similar to [Compass]() but instead of for Sass, i
 
 Getting started is fairly simple - The short version for Rails 3 is simply:
 
-1. Add `gem 'barista', '~> 1.0'` to your Gemfile
+1. Add `gem 'barista', '~> 1.0'` and `gem 'json'` to your Gemfile
 2. Run `bundle install`
 3. Run `rails generate barista:install`
 

--- a/lib/barista/tasks/barista.rake
+++ b/lib/barista/tasks/barista.rake
@@ -3,7 +3,11 @@ namespace :barista do
   desc "Compiles coffeescripts from app/coffeescripts into public/javascripts"
   task :brew => :environment do
     if !Barista::Compiler.available?
-      $stderr.puts "'#{Barista::Compiler.bin_path}' was unavailable."
+      if Barista::Compiler.bin_path.nil?
+        $stderr.puts "Looks like Coffescript is not installed."
+      else
+        $stderr.puts "'#{Barista::Compiler.bin_path}' was unavailable."
+      end
       exit 1
     end
     Barista.compile_all! true, false


### PR DESCRIPTION
That generated an exception when executing:

$ rails generate barista:install
/home/anibal/.rvm/gems/ruby-1.8.7-p299/gems/activesupport-3.0.5/lib/active_support/dependencies.rb:239:in `require': no such file to load -- json (LoadError)
    from /home/anibal/.rvm/gems/ruby-1.8.7-p299/gems/activesupport-3.0.5/lib/active_support/dependencies.rb:239:in`require'
    from /home/anibal/.rvm/gems/ruby-1.8.7-p299/gems/activesupport-3.0.5/lib/active_support/dependencies.rb:225:in `load_dependency'
    from /home/anibal/.rvm/gems/ruby-1.8.7-p299/gems/activesupport-3.0.5/lib/active_support/dependencies.rb:596:in`new_constants_in'
    from /home/anibal/.rvm/gems/ruby-1.8.7-p299/gems/activesupport-3.0.5/lib/active_support/dependencies.rb:225:in `load_dependency'
    from /home/anibal/.rvm/gems/ruby-1.8.7-p299/gems/activesupport-3.0.5/lib/active_support/dependencies.rb:239:in`require'
    from /home/anibal/.rvm/gems/ruby-1.8.7-p299/gems/coffee-script-2.1.3/lib/coffee_script.rb:1
    from /home/anibal/.rvm/gems/ruby-1.8.7-p299/gems/activesupport-3.0.5/lib/active_support/dependencies.rb:239:in `require'
    from /home/anibal/.rvm/gems/ruby-1.8.7-p299/gems/activesupport-3.0.5/lib/active_support/dependencies.rb:239:in`require'
    from /home/anibal/.rvm/gems/ruby-1.8.7-p299/gems/activesupport-3.0.5/lib/active_support/dependencies.rb:225:in `load_dependency'
    from /home/anibal/.rvm/gems/ruby-1.8.7-p299/gems/activesupport-3.0.5/lib/active_support/dependencies.rb:596:in`new_constants_in'
    from /home/anibal/.rvm/gems/ruby-1.8.7-p299/gems/activesupport-3.0.5/lib/active_support/dependencies.rb:225:in `load_dependency'
    from /home/anibal/.rvm/gems/ruby-1.8.7-p299/gems/activesupport-3.0.5/lib/active_support/dependencies.rb:239:in`require'
    from /home/anibal/.rvm/gems/ruby-1.8.7-p299/gems/barista-1.0.0/lib/barista.rb:3
