### PR TITLE
Namespacing based on relative file path

### DIFF
--- a/lib/barista.rb
+++ b/lib/barista.rb
@@ -57,7 +57,7 @@ module Barista
 
     # Configuration - Tweak how you use Barista.
 
-    has_boolean_options    :verbose, :bare, :add_filter, :add_preamble, :exception_on_error, :embedded_interpreter, :auto_compile
+    has_boolean_options    :verbose, :bare, :add_filter, :add_preamble, :exception_on_error, :embedded_interpreter, :auto_compile, :add_namespaces
     has_delegate_methods   Compiler, :bin_path, :bin_path=, :js_path, :js_path=
     has_delegate_methods   Framework, :register
     has_deprecated_methods :compiler, :compiler=, :compiler_klass, :compiler_klass=
@@ -173,6 +173,10 @@ module Barista
 
     def default_for_auto_compile
       true
+    end
+    
+    def default_for_add_namespaces
+      false
     end
 
 

--- a/lib/barista/helpers.rb
+++ b/lib/barista/helpers.rb
@@ -41,6 +41,13 @@ module Barista
       end
     end
     
+    def coffeescript_namespace_init_tag(controller = params[:controller], action = params[:action])
+      output = defined?(ActiveSupport::SafeBuffer) ? ActiveSupport::SafeBuffer.new : ""
+      output << "#{controller.gsub('/', '_')}.init();\n"
+      output << "#{controller.gsub('/', '_')}.#{action}();"
+      javascript_tag output
+    end
+    
     protected
     
     def normalise_coffeescript_path(path)

--- a/lib/generators/barista/install/templates/initializer.rb
+++ b/lib/generators/barista/install/templates/initializer.rb
@@ -58,5 +58,9 @@ Barista.configure do |c|
   # Make helpers and the HAML filter output coffee-script instead of the compiled JS.
   # Used in combination with the coffeescript_interpreter_js helper in Rails.
   # c.embedded_interpreter = true
+  
+  # Wrap compiled JS in namespacing functions. Call these with the coffeescript_namespace_init_tag helper
+  # When used in combination with a JS packager allows you to have 1 JS file per site; calling only functions for current controller & action.
+  # c.add_namespacing = true
 
 end


### PR DESCRIPTION
Added namespacing feature to barista. Based somewhat off this blog post: http://topsecretproject.finitestatemachine.com/2010/04/how-to-organizing-javascript-in-ruby-on-rails/

Puts an object wrapper around the compiled output which is then called from JS outputted by a helper method.

Supports controller and action level granularity Ie. 'pages/pages.coffee' will run on all actions in pages controller whilst 'pages/home.coffee' will run only on 'pages#home' action. Support namespaced controllers such as 'devise/registrations/new.coffee'.

The idea is that you can combine this with something like rack-pagespeed to minify and combine your javascript's into one file so you have only one HTTP request but still have granular control over which code runs without having to manage namespaces inside the .coffee files yourself.
