### PR TITLE
Support for rake tasks in rails 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,16 @@ Much like on Rails 3, Barista supports deep integration into Rails 2. The only t
 
     gem "json" # Only needed if on Ruby 1.8 / a platform that ships without JSON
     gem "barista"
-    
+
 To your `Gemfile`. If you're not using bundler, doing `gem install json barista` and requiring barista both in your application should be enough to get you started.
 
 If you wish to change the barista configuration, take a look at the  [Rails 3 initializer](https://github.com/Sutto/barista/blob/master/lib/generators/barista/install/templates/initializer.rb) and modify it to suite your application as needed.
+
+If you wish to use barista tasks with rails 2 project, add
+
+    require "barista/tasks"
+
+To your `Rakefile`.
 
 ### Sinatra
 
@@ -62,7 +68,7 @@ For example, your `config.ru` may look like:
     use Barista::Filter if Barista.add_filter?
     use Barista::Server::Proxy
     run MyRackApplication
-    
+
 Next, you need to configure barista anywhere before your the above code is run. e.g by adding the following immediatly preceeding it:
 
     # Barista (for CoffeeScript Support)
@@ -71,7 +77,7 @@ Next, you need to configure barista anywhere before your the above code is run. 
     Barista.setup_defaults
     barista_config = root + '/barista_config.rb'
     require barista_config if File.exist?(barista_config)
-    
+
 Hence, if you'e using, for example, [serve](https://github.com/jlong/serve) users should have a `config.ru` that looks similar to [this example](https://github.com/YouthTree/site-design/blob/master/config.ru).
 
 ### A Quick Note on the JSON Gem

--- a/lib/barista/rake_task.rb
+++ b/lib/barista/rake_task.rb
@@ -1,4 +1,3 @@
-require 'barista'
 require 'rake'
 require 'rake/tasklib'
 
@@ -45,6 +44,8 @@ module Barista
     private
 
     def setup_barista
+      require 'barista'
+
       Barista.env = @environment if @environment
       if @input_directory
         Barista.root = File.expand_path(@input_directory, Dir.pwd)

--- a/lib/barista/rake_task.rb
+++ b/lib/barista/rake_task.rb
@@ -1,4 +1,4 @@
-require 'barista' unless defined?(Barista)
+require 'barista'
 require 'rake'
 require 'rake/tasklib'
 

--- a/lib/barista/tasks.rb
+++ b/lib/barista/tasks.rb
@@ -1,0 +1,1 @@
+load 'barista/tasks/barista.rake'


### PR DESCRIPTION
Barista is bundled with rake task called `barista:brew`. It's located inside `barista/tasks` folder as a default location for Rails 3 to pick up tasks. But other frameworks like rails 2.3 and sinatra don't load tasks by default from gems. So unfortunate owners of such projects need to manually load appropriate file like:

`load 'barista/tasks/barista.rake'`

But default convention for rails 2.3 gems is to provide a helper file to include such tasks like `require 'gem_name/tasks'` so I've added such file.

But turns out there is another problem, barista is required in `rake_task.rb` immediately, therefore we get `rake aborted! uninitialized constant Barista::Integration::Rails2::ActionController` since environment for rails project isn't loaded yet. To fix this I've postponed requirement of barista in `rake_task.rb` until barista task is called so environment will be already setup.

After applying this pull-request, any rails 2.x project owner can use barista tasks without a sweat.
