### PR TITLE
Honor Barista#verbose when determining to log debug messages

### DIFF
--- a/lib/barista.rb
+++ b/lib/barista.rb
@@ -225,7 +225,7 @@ module Barista
     end
 
     def debug(message)
-      logger.debug "[Barista] #{message}" if logger
+      logger.debug "[Barista] #{message}" if logger && verbose?
     end
 
     def setup_defaults

--- a/spec/barista_spec.rb
+++ b/spec/barista_spec.rb
@@ -62,6 +62,19 @@ describe Barista do
       Barista::compile_all!
       File.exist?(File.join(@public_path, "alert.js")).should be_true
     end
+    it "logs when verbose is true" do
+      log = StringIO.new
+      Barista.logger = Logger.new(log)
+      Barista.compile_all!
+      log.string.should =~ /\[Barista\].+/
+    end
+    it "does not log when verbose is false" do
+      log = StringIO.new
+      Barista.logger = Logger.new(log)
+      Barista.verbose = false
+      Barista.compile_all!
+      log.string.should be_empty
+    end
   end
 
 end


### PR DESCRIPTION
Currently, it logs debug messages regardless of what `Barista#verbose` is set to. That gets kind of annoying during tests.
