### PR TITLE
Add 'filter' to configuration to be able to skip compilation process

### DIFF
--- a/lib/barista.rb
+++ b/lib/barista.rb
@@ -64,6 +64,7 @@ module Barista
     has_delegate_methods   Compiler, :bin_path, :bin_path=, :js_path, :js_path=
     has_delegate_methods   Framework, :register
     has_deprecated_methods :compiler, :compiler=, :compiler_klass, :compiler_klass=
+    attr_accessor :filter
 
     def add_preamble(&blk)
       self.add_preamble = true

--- a/lib/barista/filter.rb
+++ b/lib/barista/filter.rb
@@ -6,7 +6,11 @@ module Barista
     end
 
     def call(env)
-      dup._call(env)
+      if !Barista.filter || Barista.filter.(env)
+        dup._call(env)
+      else
+        @app.call(env)
+      end
     end
 
     def _call(env)


### PR DESCRIPTION
Filter should respond to 'call' and return false when there is no need for compilation.

Rationale: Recompilation of all coffeescripts on each request is very slow. We should recompile more rarely.

For example, to skip certain extensions we can

```
Barista.configure do |c|
  c.add_filter = true
  c.filter = lambda do |env|
    skip_extensions = %w(.js .json .css .png .jpg .jpeg .gif .ico .woff)
    extension = File.extname(env["PATH_INFO"])
    !skip_extensions.include?(extension)
  end
end
```
